### PR TITLE
add option to pass in an init command which is run on update

### DIFF
--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -5,6 +5,7 @@ set -o pipefail
 
 APP_TARBALL="$1"
 APP_PATH="<%= locals.remote_app_path %>"
+INIT_CMD="<%= locals.init_cmd %>"""
 PULLPREVIEW_ENV_FILE="/etc/pullpreview/env"
 
 lock_file="/tmp/update.lock"
@@ -67,6 +68,12 @@ cd "$APP_PATH"
 if ! /tmp/pre_script.sh ; then
   echo "Failed to run the pre-script"
   exit 1
+fi
+
+if [ -n "$INIT_CMD" ] ; then
+  echo "Command to be executed: $INIT_CMD"
+  bash -c "$INIT_CMD"
+  exit $?
 fi
 
 pull() {

--- a/lib/pull_preview/instance.rb
+++ b/lib/pull_preview/instance.rb
@@ -132,7 +132,12 @@ module PullPreview
         public_dns: public_dns,
         admins: admins,
         url: url,
+        init_cmd: init_cmd
       )
+    end
+
+    def init_cmd
+      ENV.fetch("INIT_CMD", "")
     end
 
     def github_token


### PR DESCRIPTION
As we're having our own wrapper command around docker-compose, it would be great to have the option to pass in an init command instead