### PR TITLE
Introduce scheduled cleanup for dangling resources

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -1,5 +1,7 @@
 name: pullpreview
 on:
+  schedule:
+    - cron: "30 2 * * *"
   push:
     branches:
       - master

--- a/bin/pullpreview
+++ b/bin/pullpreview
@@ -76,7 +76,7 @@ begin
       exit 1
     end
 
-    PullPreview::SyncWithGithub.run(app_path, opts.to_hash)
+    PullPreview::GithubSync.run(app_path, opts.to_hash)
   when "console"
     binding.pry
   when "list"

--- a/lib/pull_preview.rb
+++ b/lib/pull_preview.rb
@@ -6,7 +6,7 @@ require_relative "./pull_preview/error"
 require_relative "./pull_preview/instance"
 require_relative "./pull_preview/up"
 require_relative "./pull_preview/down"
-require_relative "./pull_preview/sync_with_github"
+require_relative "./pull_preview/github_sync"
 require_relative "./pull_preview/list"
 require_relative "./pull_preview/license"
 


### PR DESCRIPTION
If event name is `schedule`, the action will attempt to clean up any closed PR that still has the `pullpreview` label (and possibly a corresponding environment in Lightsail). This can happen whenever GitHub Action fails to run the pullpreview action after a PR is closed/merged.