### PR TITLE
Switch to amazon linux 2 since the old blueprint became unavailable

### DIFF
--- a/lib/pull_preview/up.rb
+++ b/lib/pull_preview/up.rb
@@ -35,7 +35,7 @@ module PullPreview
 
         blueprint_id = PullPreview.lightsail.get_blueprints.blueprints.find do |blueprint|
           blueprint.platform == "LINUX_UNIX" &&
-            blueprint.group == "amazon-linux" &&
+            blueprint.group == "amazon_linux_2" &&
             blueprint.is_active &&
             blueprint.type == "os"
         end.blueprint_id


### PR DESCRIPTION
- Amazon Linux has been pulled from available blueprints after it had been deprecated on December 31, 2020
- Switching to the `amazon_linux_2` group seems do already do the trick
- unsure if other stuff needs to be changed