### PR TITLE
Security: Fix too many open ports on host system

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   ports:
     description: "Ports to open for external access on the preview server (port 22 is always open), comma-separated"
     required: false
-    default: "80/tcp,443/tcp,1000-10000/tcp"
+    default: "80/tcp,443/tcp"
   cidrs:
     description: "The IP address, or range of IP addresses in CIDR notation, that are allowed to connect to the instance"
     required: false

--- a/bin/pullpreview
+++ b/bin/pullpreview
@@ -29,7 +29,7 @@ up_opts = lambda do |o|
   o.array '--registries', 'URIs of docker registries to authenticate against, e.g. docker://username:password@ghcr.io', default: []
   o.string '--dns', 'Enable DNS support for pretty-looking URLs', default: "my.pullpreview.com"
   o.array '--ports', 'Ports to open for external access on the preview server', default: [
-    "80/tcp", "443/tcp", "1000-10000/tcp"
+    "80/tcp", "443/tcp"
   ]
   o.string '--instance-type', 'Instance type to use', default: 'small_2_0'
   o.string '--default-port', 'Default port to use when displaying the instance hostname', default: "80"


### PR DESCRIPTION
If we open more ports than needed for previewing our apps than we absolutely needed, it is likely that some external party running port scans on the host (e.g. due to the use of letsencrypt). If we then for example expose services on these ports (like a mysql or postgres server) and use empty root credentials, anyone could gain access to our data quite easily. We should not make this a default setting but leave it up to the user opening these ports or port ranges.