### PR TITLE
Allow to specify deployment variants

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -10,7 +10,7 @@ on:
     types: [labeled, unlabeled, synchronize, closed, reopened]
 
 jobs:
-  deploy_env1:
+  deploy:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview')
     timeout-minutes: 30
@@ -22,25 +22,6 @@ jobs:
           always_on: master,v5
           app_path: ./examples/wordpress
           instance_type: micro_2_0
-          deployment_variant: env1
-          dns: custom.pullpreview.com
-          registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
-        env:
-          AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-          AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  deploy_env2:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview')
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v2
-      - uses: "./"
-        with:
-          admins: crohr
-          always_on: master,v5
-          app_path: ./examples/wordpress
-          instance_type: micro_2_0
-          deployment_variant: env2
           dns: custom.pullpreview.com
           registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
         env:

--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -10,7 +10,7 @@ on:
     types: [labeled, unlabeled, synchronize, closed, reopened]
 
 jobs:
-  deploy:
+  deploy_env1:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview')
     timeout-minutes: 30
@@ -23,6 +23,24 @@ jobs:
           app_path: ./examples/wordpress
           instance_type: micro_2_0
           deployment_variant: env1
+          dns: custom.pullpreview.com
+          registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
+        env:
+          AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+  deploy_env2:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview')
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "./"
+        with:
+          admins: crohr
+          always_on: master,v5
+          app_path: ./examples/wordpress
+          instance_type: micro_2_0
+          deployment_variant: env2
           dns: custom.pullpreview.com
           registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
         env:

--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -18,10 +18,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: "./"
         with:
-          admins: crohr,qbonnard
+          admins: crohr
           always_on: master,v5
           app_path: ./examples/wordpress
           instance_type: micro_2_0
+          deployment_variant: env1
           dns: custom.pullpreview.com
           registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .env*
+tempkey

--- a/action.yml
+++ b/action.yml
@@ -38,10 +38,22 @@ inputs:
     description: "Compose files to use when running docker-compose up, comma-separated"
     required: false
     default: "docker-compose.yml"
+  license:
+    description: "PullPreview license"
+    required: false
+    default: ""
   instance_type:
     description: "Instance type to use"
     required: false
     default: "small_2_0"
+  deployment_variant:
+    description: "Deployment variant, which allows launching multiple deployments per PR (4 chars max)"
+    required: false
+    default: ""
+  provider:
+    description: "Cloud provider to use: lightsail"
+    required: false
+    default: "lightsail"
   registries:
     description: "Names of private registries to authenticate against. E.g. docker://username:password@ghcr.io"
     required: false
@@ -77,7 +89,11 @@ runs:
     - "${{ inputs.always_on }}"
     - "--instance-type"
     - "${{ inputs.instance_type }}"
+    - "--deployment-variant"
+    - "${{ inputs.deployment_variant }}"
     - "--registries"
     - "${{ inputs.registries }}"
   env:
     GITHUB_TOKEN: "${{ inputs.github_token }}"
+    PULLPREVIEW_LICENSE: "${{ inputs.license }}"
+    PULLPREVIEW_PROVIDER: "${{ inputs.provider }}"

--- a/bin/pullpreview
+++ b/bin/pullpreview
@@ -11,7 +11,8 @@ STDERR.sync = true
 
 PullPreview.logger = Logger.new(STDOUT)
 PullPreview.logger.level = Logger.const_get(ENV.fetch("PULLPREVIEW_LOGGER_LEVEL", "INFO"))
-PullPreview.lightsail = Aws::Lightsail::Client.new(region: ENV.fetch("AWS_REGION", "us-east-1"))
+PullPreview.license = ENV.fetch("PULLPREVIEW_LICENSE", "")
+PullPreview.provider = ENV.fetch("PULLPREVIEW_PROVIDER", "lightsail")
 
 common_opts = lambda do |o|
   o.bool '-v', '--verbose', 'Enable verbose mode' do
@@ -36,6 +37,7 @@ up_opts = lambda do |o|
   o.array '--tags', 'Tags to add to the instance'
   o.array '--compose-files', 'Compose files to use when running docker-compose up', default: ["docker-compose.yml"]
 end
+
 
 begin
   case ARGV.shift
@@ -66,8 +68,9 @@ begin
     opts = Slop.parse do |o|
       o.banner = "Usage: pullpreview github-sync path/to/app [options]"
       common_opts.call(o)
-      up_opts.call(o)
+      o.string '--deployment-variant', 'Deployment variant, which allows launching multiple deployments per PR (4 chars max)', default: ""
       o.array '--always-on', 'List of branches to always deploy', default: []
+      up_opts.call(o)
     end
 
     app_path = opts.arguments.first
@@ -80,19 +83,22 @@ begin
   when "console"
     binding.pry
   when "list"
-    PullPreview::List.run(ARGV)
+    opts = Slop.parse do |o|
+      o.banner = "Usage: pullpreview list org/repo [options]"
+      common_opts.call(o)
+      o.string '--org', 'Restrict to given organization name'
+      o.string '--repo', 'Restrict to given repository name'
+    end
+    PullPreview::List.run(opts)
   else
     puts "Usage: pullpreview [up|down|list|console|github-sync] [options]"
     exit 1
   end
-rescue PullPreview::Error => e
+rescue PullPreview::Error, StandardError => e
   puts "Error: #{e.message}"
+  PullPreview.logger.debug e.backtrace.join("\n")
   exit 1
 rescue Slop::Error => e
   puts "CLI Error: #{e.message}"
-  exit 1
-rescue Aws::Lightsail::Errors::ServiceError => e
-  puts "AWS Error: #{e.message}"
-  PullPreview.logger.debug e.backtrace.join("\n")
   exit 1
 end

--- a/lib/pull_preview.rb
+++ b/lib/pull_preview.rb
@@ -1,8 +1,11 @@
 require "logger"
 require "fileutils"
-require "aws-sdk-lightsail"
 
+require_relative "./pull_preview/providers"
 require_relative "./pull_preview/error"
+require_relative "./pull_preview/utils"
+require_relative "./pull_preview/user_data"
+require_relative "./pull_preview/access_details"
 require_relative "./pull_preview/instance"
 require_relative "./pull_preview/up"
 require_relative "./pull_preview/down"
@@ -17,7 +20,7 @@ module PullPreview
 
   class << self
     attr_accessor :logger
-    attr_accessor :lightsail
+    attr_reader :license, :provider
   end
 
   def self.data_dir
@@ -35,5 +38,16 @@ module PullPreview
       conn.request(:retry, max: 2)
       conn.request  :url_encoded
     end
+  end
+
+  def self.license=(value)
+    @license = value
+    @license = nil if @license.empty?
+    @license
+  end
+
+  # +value+: one of lightsail,pullpreview
+  def self.provider=(value)
+    @provider = Providers.fetch(value)
   end
 end

--- a/lib/pull_preview/access_details.rb
+++ b/lib/pull_preview/access_details.rb
@@ -1,0 +1,16 @@
+module PullPreview
+  class AccessDetails
+    attr_reader :username, :ip_address, :private_key, :cert_key
+
+    def initialize(username:, ip_address:, private_key: nil, cert_key: nil)
+      @username = username
+      @ip_address = ip_address
+      @private_key = private_key
+      @cert_key = cert_key
+    end
+
+    def ssh_address
+      [username, ip_address].compact.join("@")
+    end
+  end
+end

--- a/lib/pull_preview/down.rb
+++ b/lib/pull_preview/down.rb
@@ -3,7 +3,7 @@ module PullPreview
     def self.run(opts)
       instance = Instance.new(opts[:name])
       PullPreview.logger.info "Destroying instance name=#{instance.name}"
-      instance.destroy!
+      instance.terminate!
     end
   end
 end

--- a/lib/pull_preview/instance.rb
+++ b/lib/pull_preview/instance.rb
@@ -61,6 +61,10 @@ module PullPreview
       end
     end
 
+    def running?
+      provider.running?(name)
+    end
+
     def ssh_ready?
       ssh("test -f /etc/pullpreview/ready")
     end

--- a/lib/pull_preview/providers.rb
+++ b/lib/pull_preview/providers.rb
@@ -1,0 +1,8 @@
+module PullPreview
+  module Providers
+    def self.fetch(name)
+      require_relative "./providers/#{name.downcase}"
+      const_get(name.capitalize).new
+    end
+  end
+end

--- a/lib/pull_preview/providers/lightsail.rb
+++ b/lib/pull_preview/providers/lightsail.rb
@@ -1,0 +1,183 @@
+module PullPreview
+  module Providers
+    class Lightsail
+      include Utils
+
+      attr_reader :client
+
+      SIZES = {
+        "XXS" => "nano_2_0",
+        "XS" => "micro_2_0",
+        "S" => "small_2_0",
+        "M" => "medium_2_0",
+        "L" => "large_2_0",
+        "XL" => "xlarge_2_0",
+        "2XL" => "2xlarge_2_0",
+      }
+
+      def initialize
+        require "aws-sdk-lightsail"
+        @aws_region = ENV.fetch("AWS_REGION", "us-east-1")
+        @client = Aws::Lightsail::Client.new(region: @aws_region)
+      end
+
+      def running?(name)
+        resp = client.get_instance_state(instance_name: name)
+        resp.state.name == "running"
+      rescue Aws::Lightsail::Errors::NotFoundException
+        false
+      end
+
+      def terminate!(name)
+        operation = client.delete_instance(instance_name: name).operations.first
+        if operation.error_code.nil?
+          true
+        else
+          raise Error, "An error occurred while destroying the instance: #{operation.error_code} (#{operation.error_details})"
+        end
+      end
+
+      def launch!(name, size:, ssh_public_keys: [], user_data: UserData.new, cidrs: [], ports: [], tags: {})
+        unless running?(name)
+          launch_or_restore_from_snapshot(name, user_data: user_data, size: size, ssh_public_keys: ssh_public_keys, tags: tags)
+          sleep 2
+          wait_until_running!(name)
+        end
+        setup_firewall(name, cidrs: cidrs, ports: ports)
+        fetch_access_details(name)
+      end
+
+      def launch_or_restore_from_snapshot(name, user_data:, size:, ssh_public_keys: [], tags: {})
+        params = {
+          instance_names: [name],
+          availability_zone: availability_zones.first,
+          bundle_id: bundle_id(size),
+          tags: {stack: PullPreview::STACK_NAME}.merge(tags).map{|(k,v)| {key: k.to_s, value: v.to_s}},
+        }
+
+        if latest_snapshot(name)
+          logger.info "Found snapshot to restore from: #{latest_snapshot.name}"
+          logger.info "Creating new instance name=#{name}..."
+          client.create_instances_from_snapshot(params.merge({
+            user_data: user_data.to_s,
+            instance_snapshot_name: latest_snapshot.name,
+          }))
+        else
+          logger.info "Creating new instance name=#{name}..."
+          client.create_instances(params.merge({
+            user_data: user_data.to_s,
+            blueprint_id: blueprint_id
+          }))
+        end
+      end
+
+      def wait_until_running!(name)
+        if wait_until { logger.info "Waiting for instance to be running" ; running?(name) }
+          logger.debug "Instance is running"
+        else
+          logger.error "Timeout while waiting for instance running"
+          raise Error, "Instance still not running. Aborting."
+        end
+      end
+
+      def setup_firewall(name, cidrs: [], ports: [])
+        client.put_instance_public_ports({
+          port_infos: ports.map do |port_definition|
+            port_range, protocol = port_definition.split("/", 2)
+            protocol ||= "tcp"
+            port_range_start, port_range_end = port_range.split("-", 2)
+            port_range_end ||= port_range_start
+            cidrs_to_use = cidrs
+            if port_range_start.to_i == 22
+              # allow SSH from anywhere
+              cidrs_to_use = ["0.0.0.0/0"]
+            end
+            {
+              from_port: port_range_start.to_i,
+              to_port: port_range_end.to_i,
+              protocol: protocol, # accepts tcp, all, udp
+              cidrs: cidrs_to_use,
+            }
+          end,
+          instance_name: name
+        })
+      end
+
+      def fetch_access_details(name)
+        result = client.get_instance_access_details({
+          instance_name: name,
+          protocol: "ssh", # accepts ssh, rdp
+        }).access_details
+        AccessDetails.new(username: result.username, ip_address: result.ip_address, cert_key: result.cert_key, private_key: result.private_key)
+      end
+
+      def latest_snapshot(name)
+        client.get_instance_snapshots.instance_snapshots.sort{|a,b| b.created_at <=> a.created_at}.find do |snap|
+          snap.state == "available" && snap.from_instance_name == name
+        end
+      end
+
+      def list_instances(tags: {})
+        next_page_token = nil
+        begin
+          result = client.get_instances(next_page_token: next_page_token) 
+          next_page_token = result.next_page_token
+          result.instances.each do |instance|
+            matching_tags = Hash[instance.tags.select{|tag| tags.keys.include?(tag.key)}.map{|tag| [tag.key, tag.value]}]
+            if matching_tags == tags
+              yield(OpenStruct.new(
+                name: instance.name,
+                public_ip: instance.public_ip_address,
+                size: SIZES.invert.fetch(instance.bundle_id, instance.bundle_id),
+                region: instance.location.region_name,
+                zone: instance.location.availability_zone,
+                created_at: instance.created_at,
+                tags: instance.tags,
+              ))
+            end
+          end
+        end while not next_page_token.nil?
+      end
+
+      def availability_zones
+        azs = client.get_regions(include_availability_zones: true).regions.find do |region|
+          region.name == @aws_region
+        end.availability_zones.map(&:zone_name)
+      end
+
+      def blueprint_id
+        blueprint_id = client.get_blueprints.blueprints.find do |blueprint|
+          blueprint.platform == "LINUX_UNIX" &&
+            blueprint.group == "amazon_linux_2" &&
+            blueprint.is_active &&
+            blueprint.type == "os"
+        end.blueprint_id
+      end
+
+      def username
+        "ec2-user"
+      end
+
+      def bundle_id(size = "M")
+        instance_type = SIZES.fetch(size, size)
+        bundle_id = client.get_bundles.bundles.find do |bundle|
+          if instance_type.nil? || instance_type.empty?
+            bundle.cpu_count >= 1 &&
+              (2..3).include?(bundle.ram_size_in_gb) &&
+              bundle.supported_platforms.include?("LINUX_UNIX")
+          else
+            bundle.bundle_id == instance_type
+          end
+        end.bundle_id
+      end
+
+      private def remote_app_path
+        PullPreview::REMOTE_APP_PATH
+      end
+
+      private def logger
+        PullPreview.logger
+      end
+    end
+  end
+end

--- a/lib/pull_preview/up.rb
+++ b/lib/pull_preview/up.rb
@@ -17,7 +17,6 @@ module PullPreview
         app_path = "/tmp/app"
       end
 
-      aws_region = PullPreview.lightsail.config.region
       instance_name = opts[:name]
 
       PullPreview.logger.info "Taring up repository at #{app_path.inspect}..."
@@ -26,46 +25,27 @@ module PullPreview
       end
 
       instance = Instance.new(instance_name, opts)
-
-      unless instance.running?
-        PullPreview.logger.info "Starting instance name=#{instance.name}"
-        azs = PullPreview.lightsail.get_regions(include_availability_zones: true).regions.find do |region|
-          region.name == aws_region
-        end.availability_zones.map(&:zone_name)
-
-        blueprint_id = PullPreview.lightsail.get_blueprints.blueprints.find do |blueprint|
-          blueprint.platform == "LINUX_UNIX" &&
-            blueprint.group == "amazon_linux_2" &&
-            blueprint.is_active &&
-            blueprint.type == "os"
-        end.blueprint_id
-
-        bundle_id = PullPreview.lightsail.get_bundles.bundles.find do |bundle|
-          if opts[:instance_type].nil? || opts[:instance_type].empty?
-            bundle.cpu_count >= 1 &&
-              (2..3).include?(bundle.ram_size_in_gb) &&
-              bundle.supported_platforms.include?("LINUX_UNIX")
-          else
-            bundle.bundle_id == opts[:instance_type]
-          end
-        end.bundle_id
-
-        instance.launch(azs.first, bundle_id, blueprint_id, tags)
-        instance.wait_until_running!
-        sleep 2
-      end
+      PullPreview.logger.info "Starting instance name=#{instance.name}"
+      instance.launch_and_wait_until_ready!
 
       PullPreview.logger.info "Synchronizing instance name=#{instance.name}"
-      instance.open_ports
-      instance.wait_until_ssh_ready!
       instance.setup_ssh_access
       instance.setup_update_script
       instance.setup_prepost_scripts
 
-      puts
-      puts "To connect to the instance (authorized GitHub users: #{instance.admins.join(", ")}):"
-      puts "  ssh #{instance.ssh_address}"
-      puts
+      connection_instructions = [
+        "",
+        "To connect to the instance (authorized GitHub users: #{instance.admins.join(", ")}):",
+        "  ssh #{instance.ssh_address}",
+        ""
+      ].join("\n")
+
+      heartbeat = Thread.new do
+        loop do
+          puts connection_instructions
+          sleep 10
+        end
+      end
 
       PullPreview.logger.info "Preparing to push app tarball (#{(File.size("/tmp/app.tar.gz") / 1024.0**2).round(2)}MB)"
       remote_tarball_path = "/tmp/app-#{Time.now.utc.strftime("%Y%m%d%H%M%S")}.tar.gz"
@@ -77,19 +57,22 @@ module PullPreview
       PullPreview.logger.info "Launching application..."
       ok = instance.ssh("/tmp/update_script.sh #{remote_tarball_path}")
 
-      puts "::set-output name=url::#{instance.url}"
-      puts "::set-output name=host::#{instance.public_ip}"
-      puts "::set-output name=username::#{instance.username}"
+      heartbeat.kill
+
+      if github_output_file = ENV["GITHUB_OUTPUT"]
+        File.open(github_output_file, "a") do |f|
+          f.puts "url=#{instance.url}"
+          f.puts "host=#{instance.public_ip}"
+          f.puts "username=#{instance.username}"
+        end
+      end
 
       puts
       puts "You can access your application at the following URL:"
       puts "  #{instance.url}"
       puts
 
-      puts
-      puts "To ssh into the instance (authorized GitHub users: #{instance.admins.join(", ")}):"
-      puts "  ssh #{instance.ssh_address}"
-      puts
+      puts connection_instructions
 
       puts
       puts "Then to view the logs:"

--- a/lib/pull_preview/user_data.rb
+++ b/lib/pull_preview/user_data.rb
@@ -1,0 +1,37 @@
+module PullPreview
+  class UserData
+    attr_reader :app_path, :ssh_public_keys, :username
+
+    def initialize(app_path:, ssh_public_keys:, username: "ec2-user")
+      @app_path = app_path
+      @ssh_public_keys = ssh_public_keys
+      @username = username
+    end
+
+    def instructions
+      result = []
+      result << "#!/bin/bash -xe"
+      if ssh_public_keys.any?
+        result << %{echo '#{ssh_public_keys.join("\n")}' > /home/#{username}/.ssh/authorized_keys}
+      end
+      result << "mkdir -p #{app_path} && chown -R #{username}.#{username} #{app_path}"
+      result << "echo 'cd #{app_path}' > /etc/profile.d/pullpreview.sh"
+      result << "test -s /swapfile || ( fallocate -l 2G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile && echo '/swapfile none swap sw 0 0' | tee -a /etc/fstab )"
+      result << "sysctl vm.swappiness=10 && sysctl vm.vfs_cache_pressure=50"
+      result << "echo 'vm.swappiness=10' | tee -a /etc/sysctl.conf"
+      result << "echo 'vm.vfs_cache_pressure=50' | tee -a /etc/sysctl.conf"
+      result << "yum install -y docker"
+      result << %{curl -L "https://github.com/docker/compose/releases/download/v2.16.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose}
+      result << "chmod +x /usr/local/bin/docker-compose"
+      result << "usermod -aG docker #{username}"
+      result << "service docker restart"
+      result << "echo 'docker image prune -a --filter=\"until=96h\" --force' > /etc/cron.daily/docker-prune && chmod a+x /etc/cron.daily/docker-prune"
+      result << "mkdir -p /etc/pullpreview && touch /etc/pullpreview/ready && chown -R #{username}.#{username} /etc/pullpreview"
+      result
+    end
+
+    def to_s
+      instructions.join("\n")
+    end
+  end
+end

--- a/lib/pull_preview/utils.rb
+++ b/lib/pull_preview/utils.rb
@@ -1,0 +1,17 @@
+module PullPreview
+  module Utils
+    def wait_until(max_retries = 30, interval = 5, &block)
+      result = true
+      retries = 0
+      until block.call
+        retries += 1
+        if retries >= max_retries
+          result = false
+          break
+        end
+        sleep interval
+      end
+      result 
+    end
+  end
+end


### PR DESCRIPTION
Sometimes it might make sense to launch multiple environments per PR/branch. This PR introduces the `--deployment-variant` option so that the instance name and subdomain can be customised with a deployment variant.

Should address #39.