### PR TITLE
Fix deletion of instance when using deployment variants

### DIFF
--- a/.github/workflows/pullpreview-multi-env.yml
+++ b/.github/workflows/pullpreview-multi-env.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: "./"
         with:
           deployment_variant: env1
-          label: pullpreview-muli-env
+          label: pullpreview-multi-env
           admins: crohr
           app_path: ./examples/wordpress
           instance_type: micro_2_0
@@ -33,7 +33,7 @@ jobs:
       - uses: "./"
         with:
           deployment_variant: env2
-          label: pullpreview-muli-env
+          label: pullpreview-multi-env
           admins: crohr
           app_path: ./examples/wordpress
           instance_type: micro_2_0

--- a/.github/workflows/pullpreview-multi-env.yml
+++ b/.github/workflows/pullpreview-multi-env.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: "./"
         with:
           deployment_variant: env1
+          label: pullpreview-muli-env
           admins: crohr
           app_path: ./examples/wordpress
           instance_type: micro_2_0
@@ -32,6 +33,7 @@ jobs:
       - uses: "./"
         with:
           deployment_variant: env2
+          label: pullpreview-muli-env
           admins: crohr
           app_path: ./examples/wordpress
           instance_type: micro_2_0

--- a/.github/workflows/pullpreview-multi-env.yml
+++ b/.github/workflows/pullpreview-multi-env.yml
@@ -1,4 +1,4 @@
-name: pullpreview
+name: pullpreview_multi_env
 on:
   schedule:
     - cron: "45 0 * * *"

--- a/.github/workflows/pullpreview-multi-env.yml
+++ b/.github/workflows/pullpreview-multi-env.yml
@@ -1,0 +1,41 @@
+name: pullpreview
+on:
+  schedule:
+    - cron: "45 0 * * *"
+  pull_request:
+    types: [labeled, unlabeled, synchronize, closed, reopened]
+
+jobs:
+  deploy_env1:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview-multi-env' || contains(github.event.pull_request.labels.*.name, 'pullpreview-multi-env')
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "./"
+        with:
+          deployment_variant: env1
+          admins: crohr
+          app_path: ./examples/wordpress
+          instance_type: micro_2_0
+          registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
+        env:
+          AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+
+  deploy_env2:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview-multi-env' || contains(github.event.pull_request.labels.*.name, 'pullpreview-multi-env')
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "./"
+        with:
+          deployment_variant: env2
+          admins: crohr
+          app_path: ./examples/wordpress
+          instance_type: micro_2_0
+          registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
+        env:
+          AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+          AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   dns:
     description: "Which DNS suffix to use"
     default: "my.pullpreview.com"
+  label:
+    description: "Label to use for triggering preview deployments"
+    default: "pullpreview"
   github_token:
     description: "The personal access token used to update the status of your commit"
     default: "${{ github.token }}"
@@ -81,6 +84,8 @@ runs:
     - "${{ inputs.compose_files }}"
     - "--dns"
     - "${{ inputs.dns }}"
+    - "--label"
+    - "${{ inputs.label }}"
     - "--ports"
     - "${{ inputs.ports }}"
     - "--default-port"

--- a/bin/pullpreview
+++ b/bin/pullpreview
@@ -68,8 +68,9 @@ begin
     opts = Slop.parse do |o|
       o.banner = "Usage: pullpreview github-sync path/to/app [options]"
       common_opts.call(o)
-      o.string '--deployment-variant', 'Deployment variant, which allows launching multiple deployments per PR (4 chars max)', default: ""
       o.array '--always-on', 'List of branches to always deploy', default: []
+      o.string '--deployment-variant', 'Deployment variant, which allows launching multiple deployments per PR (4 chars max)', default: ""
+      o.string '--label', 'Label to use for triggering preview deployments', default: "pullpreview"
       up_opts.call(o)
     end
 

--- a/lib/pull_preview/github_sync.rb
+++ b/lib/pull_preview/github_sync.rb
@@ -189,8 +189,8 @@ module PullPreview
       commit_status = commit_status_for(status)
       # https://developer.github.com/v3/repos/statuses/#create-a-status
       commit_status_params = {
-        context: "PullPreview",
-        description: "Environment #{status.to_s}"
+        context: ["PullPreview", deployment_variant].compact.join(" - "),
+        description: ["Environment", status].join(" ")
       }
       commit_status_params.merge!(target_url: url) if url
       PullPreview.logger.info "Setting commit status for repo=#{repo.inspect}, sha=#{sha.inspect}, status=#{commit_status.inspect}, params=#{commit_status_params.inspect}"

--- a/lib/pull_preview/github_sync.rb
+++ b/lib/pull_preview/github_sync.rb
@@ -137,7 +137,7 @@ module PullPreview
 
       # In case of labeled & unlabeled, we recheck what the PR currently has for
       # labels since actions don't execute in the order they are triggered
-      if (pr_unlabeled? && !pr_has_label?(LABEL)) || (pr_closed? && pr_has_label?(LABEL))
+      if (pr_unlabeled? && !pr_has_label?(LABEL)) || pr_closed?
         return :pr_down
       end
 

--- a/lib/pull_preview/github_sync.rb
+++ b/lib/pull_preview/github_sync.rb
@@ -105,7 +105,12 @@ module PullPreview
         end
         if pr_closed?
           PullPreview.logger.info "Removing label #{label} from PR##{pr_number}..."
-          octokit.remove_label(repo, pr_number, label)
+          begin
+            octokit.remove_label(repo, pr_number, label)
+          rescue Octokit::NotFound
+            # ignore errors when removing absent labels
+            true
+          end
         end
         update_github_status(:destroyed)
       when :pr_up, :pr_push, :branch_push

--- a/lib/pull_preview/github_sync.rb
+++ b/lib/pull_preview/github_sync.rb
@@ -4,11 +4,11 @@ module PullPreview
   class GithubSync
     attr_reader :github_context
     attr_reader :app_path
+
     # CLI options, already parsed
     attr_reader :opts
     attr_reader :always_on
-
-    LABEL = "pullpreview"
+    attr_reader :label
 
     def self.run(app_path, opts)
       github_event_name = ENV.fetch("GITHUB_EVENT_NAME")
@@ -29,10 +29,11 @@ module PullPreview
     # Go over closed pull requests that are still labelled as "pullpreview", and force the destroyal of the corresponding environments
     # This happens sometimes, when a pull request is closed, but the environment is not destroyed due to some GitHub Action hiccup.
     def self.clear_dangling_deployments(repo, app_path, opts)
-      inactive_pr_issues_still_labeled = PullPreview.octokit.get("repos/#{repo}/issues", labels: LABEL, pulls: true, state: "closed")
+      label = opts[:label]
+      inactive_pr_issues_still_labeled = PullPreview.octokit.get("repos/#{repo}/issues", labels: label, pulls: true, state: "closed")
       inactive_pr_issues_still_labeled.each do |pr_issue|
         pr = PullPreview.octokit.get(pr_issue.pull_request.url)
-        PullPreview.logger.warn "Found dangling #{LABEL} label for PR##{pr.number}. Cleaning up..."
+        PullPreview.logger.warn "Found dangling #{label} label for PR##{pr.number}. Cleaning up..."
         fake_github_context = OpenStruct.new(
           action: "closed",
           number: pr.number,
@@ -69,6 +70,7 @@ module PullPreview
     def initialize(github_context, app_path, opts = {})
       @github_context = github_context
       @app_path = app_path
+      @label = opts.delete(:label)
       @opts = opts
       @always_on = opts.delete(:always_on)
     end
@@ -102,8 +104,8 @@ module PullPreview
           PullPreview.logger.warn "Instance #{instance_name.inspect} already down. Continuing..."
         end
         if pr_closed?
-          PullPreview.logger.info "Removing label #{LABEL} from PR##{pr_number}..."
-          octokit.remove_label(repo, pr_number, LABEL)
+          PullPreview.logger.info "Removing label #{label} from PR##{pr_number}..."
+          octokit.remove_label(repo, pr_number, label)
         end
         update_github_status(:destroyed)
       when :pr_up, :pr_push, :branch_push
@@ -137,19 +139,19 @@ module PullPreview
 
       # In case of labeled & unlabeled, we recheck what the PR currently has for
       # labels since actions don't execute in the order they are triggered
-      if (pr_unlabeled? && !pr_has_label?(LABEL)) || pr_closed?
+      if (pr_unlabeled? && !pr_has_label?) || pr_closed?
         return :pr_down
       end
 
-      if pr_labeled? && pr_has_label?(LABEL)
+      if pr_labeled? && pr_has_label?
         return :pr_up
       end
 
       if push? || pr_synchronize?
-        if pr_has_label?(LABEL)
+        if pr_has_label?
           return :pr_push
         else
-          PullPreview.logger.info "Unable to find label #{LABEL} on PR##{pr_number}"
+          PullPreview.logger.info "Unable to find label #{label} on PR##{pr_number}"
           return :ignored
         end
       end
@@ -313,17 +315,17 @@ module PullPreview
     def pr_labeled?
       pull_request? &&
         github_context["action"] == "labeled" &&
-        github_context["label"]["name"] == LABEL
+        github_context["label"]["name"] == label
     end
 
     def pr_unlabeled?
       pull_request? &&
         github_context["action"] == "unlabeled" &&
-        github_context["label"]["name"] == LABEL
+        github_context["label"]["name"] == label
     end
 
-    def pr_has_label?(searched_label)
-      pr.labels.find{|label| label.name.downcase == searched_label.downcase}
+    def pr_has_label?(searched_label = nil)
+      pr.labels.find{|l| l.name.downcase == (searched_label || label).downcase}
     end
 
     def pr_number


### PR DESCRIPTION
When using deployment variants, the first job to run will remove the pullpeview label from the PR, which means any other job will fail see the PR as being unlabelled and as such the job will be skipped. This PR fixes this by always testing whether the instance exists when a PR is closed/merged, and not relying on the presence/absence of the label.

It also introduces a way to customize the label to use, since this allows different workflows with different trigger rules to be used, based on the label. This came in handy to have both a single-env and a multi-env workflow for testing.