### PR TITLE
Upgrade compose to v2.18.1

### DIFF
--- a/lib/pull_preview/github_sync.rb
+++ b/lib/pull_preview/github_sync.rb
@@ -26,7 +26,7 @@ module PullPreview
       self.new(github_context, app_path, opts).sync!
     end
 
-    # Go over closed pull requests that are still labelled as "pullpreview", and force the destroyal of the corresponding environments
+    # Go over closed pull requests that are still labelled as "pullpreview", and force the removal of the corresponding environments
     # This happens sometimes, when a pull request is closed, but the environment is not destroyed due to some GitHub Action hiccup.
     def self.clear_dangling_deployments(repo, app_path, opts)
       label = opts[:label]

--- a/lib/pull_preview/user_data.rb
+++ b/lib/pull_preview/user_data.rb
@@ -21,7 +21,7 @@ module PullPreview
       result << "echo 'vm.swappiness=10' | tee -a /etc/sysctl.conf"
       result << "echo 'vm.vfs_cache_pressure=50' | tee -a /etc/sysctl.conf"
       result << "yum install -y docker"
-      result << %{curl -L "https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose}
+      result << %{curl -L "https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose}
       result << "chmod +x /usr/local/bin/docker-compose"
       result << "usermod -aG docker #{username}"
       result << "service docker restart"


### PR DESCRIPTION
This allows for `dockerfile_inline` instructions in compose files, which is useful for demos.