### PR TITLE
Add possibility to auto-stop deploymnents after a while

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -1,7 +1,7 @@
 name: pullpreview
 on:
   schedule:
-    - cron: "30 0 * * *"
+    - cron: "30 * * * *"
   push:
     branches:
       - master
@@ -9,9 +9,10 @@ on:
   pull_request:
     types: [labeled, unlabeled, synchronize, closed, reopened]
 
+concurrency: ${{ github.ref }}
+
 jobs:
   deploy:
-    concurrency: ${{ github.ref }}
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview')
     timeout-minutes: 30
@@ -25,6 +26,7 @@ jobs:
           instance_type: micro_2_0
           dns: custom.pullpreview.com
           registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
+          ttl: 1h
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: "Names of private registries to authenticate against. E.g. docker://username:password@ghcr.io"
     required: false
     default: ""
+  ttl:
+    description: "Maximum time to live for deployments (e.g. 10h, 5d, infinite)"
+    required: false
+    default: "infinite"
 
 outputs:
   url:
@@ -98,6 +102,8 @@ runs:
     - "${{ inputs.deployment_variant }}"
     - "--registries"
     - "${{ inputs.registries }}"
+    - "--ttl"
+    - "${{ inputs.ttl }}"
   env:
     GITHUB_TOKEN: "${{ inputs.github_token }}"
     PULLPREVIEW_LICENSE: "${{ inputs.license }}"

--- a/bin/pullpreview
+++ b/bin/pullpreview
@@ -71,6 +71,7 @@ begin
       o.array '--always-on', 'List of branches to always deploy', default: []
       o.string '--deployment-variant', 'Deployment variant, which allows launching multiple deployments per PR (4 chars max)', default: ""
       o.string '--label', 'Label to use for triggering preview deployments', default: "pullpreview"
+      o.string '--ttl', 'Maximum time to live for deployments (e.g. 10h, 5d, infinite)', default: "infinite"
       up_opts.call(o)
     end
 

--- a/lib/pull_preview/github_sync.rb
+++ b/lib/pull_preview/github_sync.rb
@@ -64,7 +64,7 @@ module PullPreview
           PullPreview.logger.warn "[clear_dangling_deployments] Found #{label} label for active PR##{pr.number} (#{pr_issue.updated_at}). Not touching."
           next
         end
-        # new(fake_github_context, app_path, opts).sync!
+        new(fake_github_context, app_path, opts).sync!
       end
 
       PullPreview.logger.info "[clear_dangling_deployments] end"


### PR DESCRIPTION
Introduce a new `ttl` (Time to Live) input, which allows to specify a max number of hours or days for an environment to stay up. TTL is counted from the last time the PR was updated, which means pushing new changes or performing updates on the PR will automatically extend the TTL.

After the specified time without any updates, the PR will be unlabelled and the environment destroyed. If the environment is needed again, just add the label back.

This is useful to make sure "forgotten" PRs (i.e. PRs that take an abnormal time to merge) with the label do not incur high costs.

Default is to keep instances running indefinitely. This requires the workflow to use the `schedule` trigger, for instance:

```yaml
name: pullpreview
on:
  schedule:
    - cron: "30 */4 * * *"
  pull_request:
    types: [labeled, unlabeled, synchronize, closed, reopened]
```