### PR TITLE
Use docker v2 `--wait` option

### DIFF
--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -96,6 +96,7 @@ done
 
 docker-compose <%= locals.compose_files.map{|f| ["-f", f.inspect]}.flatten.join(" ") %> up \
 	--build \
+	--wait \
 	--remove-orphans \
 	-d
 


### PR DESCRIPTION
This adds the `wait` flag which waits until containers with healthchecks are healthy. I have a rails service where we run migrations and indexing, and it can take up to 3 minutes to become healthy.  During this time the deployment shows as completed, but it is not actually ready.

https://maciejwalkowiak.com/blog/docker-compose-waiting-containers-ready/