### PR TITLE
SF - base64 encode org_id & repo_id to fix licensing request

### DIFF
--- a/lib/pull_preview/license.rb
+++ b/lib/pull_preview/license.rb
@@ -1,5 +1,6 @@
 require "json"
 require "net/http"
+require "base64"
 
 module PullPreview
   class License
@@ -17,7 +18,7 @@ module PullPreview
     end
 
     def params
-      @details.merge({org_id: @org_id, repo_id: @repo_id, pp_action: @action})
+      @details.merge({org_id: Base64.strict_encode64(@org_id.to_s), repo_id: Base64.strict_encode64(@repo_id.to_s), pp_action: @action})
     end
 
     def fetch!


### PR DESCRIPTION
Needed to add this for our org to get the licensing request to properly return.