### PR TITLE
Replace the app files atomically and docker restart instead of up for succeeding commits

### DIFF
--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -98,10 +98,11 @@ for i in {1..5}; do
   if pull; then break ; fi
 done
 
-docker-compose up \
-	--wait \
-	--remove-orphans \
-	-d <%= locals.compose_options.join(" ") %>
+if [ "$PULLPREVIEW_FIRST_RUN" = true ]; then
+  docker-compose up --wait --remove-orphans -d <%= locals.compose_options.join(" ") %>
+else
+  docker-compose restart
+fi
 
 sleep 5
 

--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -67,6 +67,8 @@ set +o allexport
 
 cd /
 
+echo $APP_PATH
+
 sudo mkdir -p "${APP_PATH}_symlink_new" && sudo chown -R ec2-user.ec2-user "${APP_PATH}_symlink_new" && tar xzf "$1" -C "${APP_PATH}_symlink_new"
 sudo ln -s "${APP_PATH}_symlink_new" "${APP_PATH}"
 sudo rm -rf "${APP_PATH}_symlink_old" || true

--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -70,8 +70,8 @@ cd /
 sudo mkdir -p "${APP_PATH}_symlink_new" && sudo chown -R ec2-user.ec2-user "${APP_PATH}_symlink_new" && tar xzf "$1" -C "${APP_PATH}_symlink_new"
 sudo ln -s "${APP_PATH}_symlink_new" "${APP_PATH}"
 sudo rm -rf "${APP_PATH}_symlink_old" || true
-sudo rename -s "${APP_PATH}_symlink_new" "${APP_PATH}_symlink_old" app
-sudo chown -R ec2-user.ec2-user "$APP_PATH_symlink_old"
+sudo mv "${APP_PATH}_symlink_new" "${APP_PATH}_symlink_old"
+sudo chown -R ec2-user.ec2-user "${APP_PATH}_symlink_old"
 
 cd "$APP_PATH"
 

--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -67,9 +67,9 @@ set +o allexport
 
 cd /
 
-tar xzf "$1" -C "${APP_PATH}_symlink_new"
+mkdir -p "${APP_PATH}_symlink_new" && tar xzf "$1" -C "${APP_PATH}_symlink_new"
 ln -s "${APP_PATH}_symlink_new" "${APP_PATH}"
-rm -rf "${APP_PATH}_symlink_old"
+rm -rf "${APP_PATH}_symlink_old" || true
 mv "${APP_PATH}_symlink_new" "${APP_PATH}_symlink_old"
 sudo chown -R ec2-user.ec2-user "$APP_PATH_symlink_old"
 

--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -70,7 +70,7 @@ cd /
 sudo mkdir -p "${APP_PATH}_symlink_new" && sudo chown -R ec2-user.ec2-user "${APP_PATH}_symlink_new" && tar xzf "$1" -C "${APP_PATH}_symlink_new"
 sudo ln -s "${APP_PATH}_symlink_new" "${APP_PATH}"
 sudo rm -rf "${APP_PATH}_symlink_old" || true
-sudo mv "${APP_PATH}_symlink_new" "${APP_PATH}_symlink_old"
+sudo rename -s "${APP_PATH}_symlink_new" "${APP_PATH}_symlink_old" app
 sudo chown -R ec2-user.ec2-user "$APP_PATH_symlink_old"
 
 cd "$APP_PATH"

--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -67,10 +67,10 @@ set +o allexport
 
 cd /
 
-mkdir -p "${APP_PATH}_symlink_new" && tar xzf "$1" -C "${APP_PATH}_symlink_new"
-ln -s "${APP_PATH}_symlink_new" "${APP_PATH}"
-rm -rf "${APP_PATH}_symlink_old" || true
-mv "${APP_PATH}_symlink_new" "${APP_PATH}_symlink_old"
+sudo mkdir -p "${APP_PATH}_symlink_new" && sudo chown -R ec2-user.ec2-user "${APP_PATH}_symlink_new" && tar xzf "$1" -C "${APP_PATH}_symlink_new"
+sudo ln -s "${APP_PATH}_symlink_new" "${APP_PATH}"
+sudo rm -rf "${APP_PATH}_symlink_old" || true
+sudo mv "${APP_PATH}_symlink_new" "${APP_PATH}_symlink_old"
 sudo chown -R ec2-user.ec2-user "$APP_PATH_symlink_old"
 
 cd "$APP_PATH"

--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -67,8 +67,7 @@ set +o allexport
 
 cd /
 
-echo $APP_PATH
-
+# Atomically replacing the app files
 sudo mkdir -p "${APP_PATH}_symlink_new" && sudo chown -R ec2-user.ec2-user "${APP_PATH}_symlink_new" && tar xzf "$1" -C "${APP_PATH}_symlink_new"
 sudo ln -s "${APP_PATH}_symlink_new" "${APP_PATH}"
 sudo rm -rf "${APP_PATH}_symlink_old" || true
@@ -99,8 +98,10 @@ for i in {1..5}; do
 done
 
 if [ "$PULLPREVIEW_FIRST_RUN" = true ]; then
+  echo "Starting up the application..."
   docker-compose up --wait --remove-orphans -d <%= locals.compose_options.join(" ") %>
 else
+  echo "Restarting the application..."
   docker-compose restart
 fi
 


### PR DESCRIPTION
In django application, everytime a commit is added it loses the link to the original files and I think its because in the script it deletes and replace the app files.

So I added two things to ensure that the refreshed files are properly loaded.

* Replace the app files atomically
* Use docker restart instead of up

Let me know your thoughts.