### PR TITLE
feat: Add the ability to execute scripts on the lightsail host

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,14 @@ inputs:
     description: "Maximum time to live for deployments (e.g. 10h, 5d, infinite)"
     required: false
     default: "infinite"
+  first_run_script:
+    description: "The path to a script to run on the server host on first run"
+    required: false
+    default: ""
+  update_run_script:
+    description: "The path to a script to run on the server host on every update"
+    required: false
+    default: ""
 
 outputs:
   url:
@@ -110,6 +118,10 @@ runs:
     - "${{ inputs.registries }}"
     - "--ttl"
     - "${{ inputs.ttl }}"
+    - "--first-run-script"
+    - "${{ inputs.first_run_script }}"
+    - "--update-run-script"
+    - "${{ inputs.update_run_script }}"
   env:
     GITHUB_TOKEN: "${{ inputs.github_token }}"
     PULLPREVIEW_LICENSE: "${{ inputs.license }}"

--- a/bin/pullpreview
+++ b/bin/pullpreview
@@ -37,7 +37,7 @@ up_opts = lambda do |o|
   o.array '--tags', 'Tags to add to the instance'
   o.array '--compose-files', 'Compose files to use when running docker-compose up', default: ["docker-compose.yml"]
   o.array '--compose-options', 'Additional options to pass to docker-compose up, comma-separated', default: ["--build"]
-  o.string '--first_run_script', 'The path to a script to run on the server host on first run', default: [""]
+  o.string '--first-run-script', 'The path to a script to run on the server host on first run', default: [""]
   o.string '--update-run-script', 'The path to a script to run on the server host on every update', default: [""]
 end
 

--- a/bin/pullpreview
+++ b/bin/pullpreview
@@ -37,6 +37,8 @@ up_opts = lambda do |o|
   o.array '--tags', 'Tags to add to the instance'
   o.array '--compose-files', 'Compose files to use when running docker-compose up', default: ["docker-compose.yml"]
   o.array '--compose-options', 'Additional options to pass to docker-compose up, comma-separated', default: ["--build"]
+  o.string '--first_run_script', 'The path to a script to run on the server host on first run', default: [""]
+  o.string '--update-run-script', 'The path to a script to run on the server host on every update', default: [""]
 end
 
 

--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -89,6 +89,7 @@ fi
 
 if $PULLPREVIEW_FIRST_RUN ; then
   if [ -f "$FIRST_RUN_SCRIPT" ]; then
+    echo "Executing $FIRST_RUN_SCRIPT"
     chmod +x $FIRST_RUN_SCRIPT
     source $FIRST_RUN_SCRIPT
     chmod -x $FIRST_RUN_SCRIPT
@@ -96,6 +97,7 @@ if $PULLPREVIEW_FIRST_RUN ; then
 fi
 
 if [ -f "$UPDATE_RUN_SCRIPT" ]; then
+  echo "Executing $UPDATE_RUN_SCRIPT"
   chmod +x $UPDATE_RUN_SCRIPT
   source $UPDATE_RUN_SCRIPT
   chmod -x $FIRST_RUN_SCRIPT

--- a/data/update_script.sh.erb
+++ b/data/update_script.sh.erb
@@ -60,6 +60,8 @@ echo 'PULLPREVIEW_PUBLIC_IP=<%= locals.public_ip %>' >> $PULLPREVIEW_ENV_FILE
 echo 'PULLPREVIEW_URL=<%= locals.url %>' >> $PULLPREVIEW_ENV_FILE
 echo "PULLPREVIEW_FIRST_RUN=$PULLPREVIEW_FIRST_RUN" >> $PULLPREVIEW_ENV_FILE
 echo "COMPOSE_FILE=<%= locals.compose_files.join(":") %>" >> $PULLPREVIEW_ENV_FILE
+echo "FIRST_RUN_SCRIPT=<%= locals.first_run_script %>" >> $PULLPREVIEW_ENV_FILE
+echo "UPDATE_RUN_SCRIPT=<%= locals.update_run_script %>" >> $PULLPREVIEW_ENV_FILE
 
 set -o allexport
 source $PULLPREVIEW_ENV_FILE
@@ -83,6 +85,20 @@ sudo yum update -y || true
 if ! /tmp/pre_script.sh ; then
   echo "Failed to run the pre-script"
   exit 1
+fi
+
+if $PULLPREVIEW_FIRST_RUN ; then
+  if [ -f "$FIRST_RUN_SCRIPT" ]; then
+    chmod +x $FIRST_RUN_SCRIPT
+    source $FIRST_RUN_SCRIPT
+    chmod -x $FIRST_RUN_SCRIPT
+  fi
+fi
+
+if [ -f "$UPDATE_RUN_SCRIPT" ]; then
+  chmod +x $UPDATE_RUN_SCRIPT
+  source $UPDATE_RUN_SCRIPT
+  chmod -x $FIRST_RUN_SCRIPT
 fi
 
 

--- a/lib/pull_preview/instance.rb
+++ b/lib/pull_preview/instance.rb
@@ -120,7 +120,7 @@ module PullPreview
         admins: admins,
         url: url,
         first_run_script: first_run_script,
-        run_script: update_run_script,
+        update_run_script: update_run_script,
       )
     end
 

--- a/lib/pull_preview/instance.rb
+++ b/lib/pull_preview/instance.rb
@@ -19,6 +19,8 @@ module PullPreview
     attr_reader :size
     attr_reader :tags
     attr_reader :access_details
+    attr_reader :first_run_script
+    attr_reader :update_run_script
 
     class << self
       attr_accessor :client
@@ -48,6 +50,8 @@ module PullPreview
       @size = opts[:instance_type]
       @ssh_results = []
       @tags = opts[:tags] || {}
+      @first_run_script = opts[:first_run_script] || ""
+      @update_run_script = opts[:update_run_script] || ""
     end
 
     def launch_and_wait_until_ready!
@@ -115,6 +119,8 @@ module PullPreview
         public_dns: public_dns,
         admins: admins,
         url: url,
+        first_run_script: first_run_script,
+        run_script: update_run_script,
       )
     end
 


### PR DESCRIPTION
I had a requirement that our Lightsail hosts needed to have an AV installed, so I needed a way to execute code on the host, but not within the Docker container we're building.

This just adds two new options to the YAML, and passed through to `data/update_script.sh.erb`

- first-run-script
-- Executes only on the first run, when `PULLPREVIEW_FIRST_RUN` is true
- update_run_script
-- Executes on every github sync to the instance

The script paths are relative to the repo directory on the lightsail host.

They could be combined, but I prefer having one script for each, instead of the same script checking the environment variable. 