### PR TITLE
Allow custom pre-script to be run

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -36,6 +36,7 @@ jobs:
           registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
           # how long this instance will stay alive (each further commit will reset the timer)
           ttl: 1h
+          pre_script: ./examples/wordpress/pre_script.sh
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"

--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -36,7 +36,8 @@ jobs:
           registries: docker://${{ secrets.GHCR_PAT }}@ghcr.io
           # how long this instance will stay alive (each further commit will reset the timer)
           ttl: 1h
-          pre_script: ./examples/wordpress/pre_script.sh
+          # preinstall script to run on the instance before docker-compose is called, relative to the app_path
+          pre_script: ./pre_script.sh
         env:
           AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ inputs:
     required: false
     default: ""
   pre_script:
-    description: "Path to a bash script to run on the instance, before calling docker compose"
+    description: "Path to a bash script to run on the instance, before calling docker compose, relative to the app_path"
     required: false
     default: ""
   ttl:

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,10 @@ inputs:
     description: "Names of private registries to authenticate against. E.g. docker://username:password@ghcr.io"
     required: false
     default: ""
+  pre_script:
+    description: "Path to a bash script to run on the instance, before calling docker compose"
+    required: false
+    default: ""
   ttl:
     description: "Maximum time to live for deployments (e.g. 10h, 5d, infinite)"
     required: false
@@ -108,6 +112,8 @@ runs:
     - "${{ inputs.deployment_variant }}"
     - "--registries"
     - "${{ inputs.registries }}"
+    - "--pre-script"
+    - "${{ inputs.pre_script }}"
     - "--ttl"
     - "${{ inputs.ttl }}"
   env:

--- a/bin/pullpreview
+++ b/bin/pullpreview
@@ -37,6 +37,7 @@ up_opts = lambda do |o|
   o.array '--tags', 'Tags to add to the instance'
   o.array '--compose-files', 'Compose files to use when running docker-compose up', default: ["docker-compose.yml"]
   o.array '--compose-options', 'Additional options to pass to docker-compose up, comma-separated', default: ["--build"]
+  o.string '--pre-script', 'Path to a bash script to run on the instance, before calling docker compose', default: ""
 end
 
 

--- a/examples/wordpress/pre_script.sh
+++ b/examples/wordpress/pre_script.sh
@@ -1,0 +1,3 @@
+echo "Hello from pre_script.sh"
+echo "This is my current env:"
+env | sort

--- a/lib/pull_preview/instance.rb
+++ b/lib/pull_preview/instance.rb
@@ -179,8 +179,8 @@ module PullPreview
           logger.warn "Registry ##{index} is invalid: #{e.message}"
         end
       end
-      unless pre_script.blank?
-        tmpfile.puts "echo 'Running pre-script at #{pre_script}...'"
+      if pre_script && !pre_script.empty?
+        tmpfile.puts "echo 'Attempting to run pre-script at #{pre_script}...'"
         tmpfile.puts "bash -e #{pre_script}"
       end
       tmpfile.flush

--- a/lib/pull_preview/instance.rb
+++ b/lib/pull_preview/instance.rb
@@ -19,6 +19,7 @@ module PullPreview
     attr_reader :size
     attr_reader :tags
     attr_reader :access_details
+    attr_reader :pre_script
 
     class << self
       attr_accessor :client
@@ -48,6 +49,7 @@ module PullPreview
       @size = opts[:instance_type]
       @ssh_results = []
       @tags = opts[:tags] || {}
+      @pre_script = opts[:pre_script]
     end
 
     def launch_and_wait_until_ready!
@@ -176,6 +178,10 @@ module PullPreview
         rescue URI::Error, Error => e
           logger.warn "Registry ##{index} is invalid: #{e.message}"
         end
+      end
+      unless pre_script.blank?
+        tmpfile.puts "echo 'Running pre-script at #{pre_script}...'"
+        tmpfile.puts "bash -e #{pre_script}"
       end
       tmpfile.flush
       unless scp(tmpfile.path, "/tmp/pre_script.sh", mode: "0755")


### PR DESCRIPTION
This will run as part of the existing system pre_script, and users can use the `PULL_PREVIEW_FIRST_RUN` env variable to differentiate between first run of PullPreview, and subsequent updates.

Fixes #87 