### PR TITLE
lowercase branch name in URL generation

### DIFF
--- a/lib/pull_preview/github_sync.rb
+++ b/lib/pull_preview/github_sync.rb
@@ -456,7 +456,7 @@ module PullPreview
         components = []
         components.push(deployment_variant) if deployment_variant
         components.push(*["pr", pr_number]) if pr_number
-        components.push(branch.split("/").last)
+        components.push(branch.split("/").last.downcase)
         Instance.normalize_name(components.join("-"))
       end
     end


### PR DESCRIPTION
A recent PR was unable to be deployed as it appears the preview URL capitalization didn't match what the ACME API normalized to. Logs from the proxy:
```
{"level":"error","ts":1729547203.6443672,"logger":"tls.obtain","msg":"will retry","error":"[pr-543-RWE-s-ip-255-255-255-255.preview.of.example.app] Obtain: [pr-543-RWE-s-ip-255-255-255-255.preview.of.example.app] validating order identifiers: identifiers in Order [{dns pr-543-rwe-s-ip-255-255-255-255.preview.of.example.app}] do not match the identifiers extracted from CSR [{dns pr-543-RWE-s-ip-255-255-255-255.preview.of.example.app}] (ca=https://acme-staging-v02.api.letsencrypt.org/directory)","attempt":8,"retrying_in":1200,"elapsed":2416.662582364,"max_duration":2592000}
```