### PR TITLE
fix: load all collaborators with push permission

### DIFF
--- a/lib/pull_preview/github_sync.rb
+++ b/lib/pull_preview/github_sync.rb
@@ -339,7 +339,10 @@ module PullPreview
       admins = opts[:admins].dup.map(&:strip)
       if admins.include?(collaborators_with_push)
         admins.delete(collaborators_with_push)
+        auto_paginate_before = octokit.auto_paginate
+        octokit.auto_paginate = true
         admins.push(*octokit.collaborators(repo).select{|c| c.permissions&.push}.map(&:login))
+        octokit.auto_paginate = auto_paginate_before
       end
       admins.uniq
     end


### PR DESCRIPTION
### Context

Currently when using the `@collaborators/push` flag for the admins it loads only the first 30 collaborators of the repository because the `auto_paginate` flag in **octokit** is set to false and the page size is 30. See API documentation https://docs.github.com/de/rest/collaborators/collaborators?apiVersion=2022-11-28 

This leads to the issue that some collaborators dont get admin access to the pullpreview.

### Changes

- Load all collaborators with push permission in `expanded_admins`